### PR TITLE
Point Next types at dev build routes

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Update `next-env.d.ts` to import route types from `./.next/dev/types/routes.d.ts` instead of the default build output.
- Align type resolution with the dev build route manifest used by this branch.

## Testing
- Not run (documentation/type-reference change only).
- Confirmed the diff updates a single import path in `next-env.d.ts`.